### PR TITLE
Avoid suppliers to front-run users by adjusting fees

### DIFF
--- a/common/api/electrum.ts
+++ b/common/api/electrum.ts
@@ -5,6 +5,7 @@ import { BridgeContract } from '../clarigen';
 import { NETWORK_CONFIG } from '../constants';
 import { Transaction } from 'bitcoinjs-lib';
 import { bytesToHex } from 'micro-stacks/common';
+import { btcToSats } from '../utils';
 
 export function getElectrumConfig() {
   const defaultHost = process.env.ELECTRUM_HOST;
@@ -103,6 +104,7 @@ export async function getTxData(txid: string, address: string) {
       return addressMatch || addressesMatch;
     });
 
+    const amount = btcToSats(tx.vout[outputIndex].value);
     const blockArg = {
       header: header,
       height: stacksHeight,
@@ -123,6 +125,7 @@ export async function getTxData(txid: string, address: string) {
       prevBlocks,
       tx,
       outputIndex,
+      amount,
     };
   });
 }

--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -15,13 +15,14 @@ interface TxData {
   txHex: Uint8Array;
   proof: ProofParam;
   outputIndex: number;
+  amount: bigint;
 }
 
 export async function fetchTxData(txid: string, address: string): Promise<TxData> {
   try {
     const url = `${LOCAL_URL || ''}/api/tx-data?txid=${txid}&address=${address}`;
     const res = await fetch(url);
-    const { block, proof, txHex, outputIndex, prevBlocks } =
+    const { block, proof, txHex, outputIndex, prevBlocks, amount } =
       (await res.json()) as unknown as TxDataApi;
     return {
       block: {
@@ -36,6 +37,7 @@ export async function fetchTxData(txid: string, address: string): Promise<TxData
         'tx-index': BigInt(proof['tx-index']),
       },
       outputIndex,
+      amount: BigInt(amount),
     };
   } catch (error) {
     console.error(error);

--- a/common/clarigen/bridge/abi.ts
+++ b/common/clarigen/bridge/abi.ts
@@ -228,6 +228,10 @@ export const BridgeInterface: ClarityAbi = {
         {
           "name": "supplier-id",
           "type": "uint128"
+        },
+        {
+          "name": "min-to-receive",
+          "type": "uint128"
         }
       ],
       "name": "escrow-swap",
@@ -2187,6 +2191,16 @@ export const BridgeInterface: ClarityAbi = {
     {
       "access": "constant",
       "name": "ERR_FEE_INVALID",
+      "type": {
+        "response": {
+          "error": "uint128",
+          "ok": "none"
+        }
+      }
+    },
+    {
+      "access": "constant",
+      "name": "ERR_INCONSISTENT_FEES",
       "type": {
         "response": {
           "error": "uint128",

--- a/common/clarigen/bridge/types.ts
+++ b/common/clarigen/bridge/types.ts
@@ -14,7 +14,7 @@ export interface BridgeContract {
   "hashes": Uint8Array[];
   "tree-depth": bigint;
   "tx-index": bigint
-    }, outputIndex: number | bigint, sender: Uint8Array, recipient: Uint8Array, expirationBuff: Uint8Array, hash: Uint8Array, swapperBuff: Uint8Array, supplierId: number | bigint) => ContractCalls.Public<{
+    }, outputIndex: number | bigint, sender: Uint8Array, recipient: Uint8Array, expirationBuff: Uint8Array, hash: Uint8Array, swapperBuff: Uint8Array, supplierId: number | bigint, minToReceive: number | bigint) => ContractCalls.Public<{
   "csv": bigint;
   "output-index": bigint;
   "redeem-script": Uint8Array;

--- a/common/hooks/tx/use-escrow-swap.ts
+++ b/common/hooks/tx/use-escrow-swap.ts
@@ -20,7 +20,7 @@ export const useEscrowSwap = (swap: InboundSwapSent) => {
     const swapperHex = numberToLE(swapperId);
     const amount = txData.amount;
     const amountWithFeeRate = (amount * (10000n - intToBigInt(supplier.inboundFee))) / 10000n;
-    const minToReceive = amountWithFeeRate - intToBigInt(supplier.inboundBaseFee);
+    const minToReceive = amountWithFeeRate - BigInt(supplier.inboundBaseFee);
     const escrowTx = contracts.bridge.contract.escrowSwap(
       txData.block,
       txData.prevBlocks,

--- a/contracts/bridge.clar
+++ b/contracts/bridge.clar
@@ -100,6 +100,8 @@
 (define-constant ERR_INSUFFICIENT_AMOUNT (err u24))
 (define-constant ERR_REVOKE_OUTBOUND_NOT_EXPIRED (err u25))
 (define-constant ERR_REVOKE_OUTBOUND_IS_FINALIZED (err u26))
+(define-constant ERR_INCONSISTENT_FEES (err u27))
+
 
 ;; Register a supplier and add funds.
 ;; Validates that the public key and "controller" (STX address) are not
@@ -303,6 +305,7 @@
 ;; @param hash; a hash of the `preimage` used in this swap
 ;; @param swapper-buff; a 4-byte integer that indicates the `swapper-id`
 ;; @param supplier-id; the supplier used in this swap
+;; @param min-to-receive; minimum receivable calculated off-chain to avoid the supplier front-run the swap by adjusting fees
 (define-public (escrow-swap
     (block { header: (buff 80), height: uint })
     (prev-blocks (list 10 (buff 80)))
@@ -315,6 +318,7 @@
     (hash (buff 32))
     (swapper-buff (buff 4))
     (supplier-id uint)
+    (min-to-receive uint)
   )
   (let
     (
@@ -360,6 +364,7 @@
     (asserts! (is-eq (len hash) u32) ERR_INVALID_HASH)
     (asserts! (map-insert inbound-swaps txid escrow) ERR_TXID_USED)
     (asserts! (map-insert inbound-meta txid meta) ERR_PANIC)
+    (asserts! (>= xbtc min-to-receive) ERR_INCONSISTENT_FEES)
     (unwrap! (map-get? swapper-by-id swapper-id) ERR_SWAPPER_NOT_FOUND)
     (map-set supplier-funds supplier-id new-funds)
     (map-set supplier-escrow supplier-id new-escrow)

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -673,10 +673,9 @@ describe('validating inbound swaps', () => {
 
     // Test inbound fee
     const inFee = supplierInfo['inbound-fee'];
-    const newInFee = inFee === null ? inFee : inFee + 10n;
     await t.txOk(
       contract.updateSupplierFees(
-        newInFee,
+        supplierInfo['inbound-fee']! + 10n,
         supplierInfo['outbound-fee'],
         supplierInfo['outbound-base-fee'],
         supplierInfo['inbound-base-fee']


### PR DESCRIPTION
This adds a parameter to the escrow-swap to make sure a minimum amount is transfered when swapping.

@dumbledope One thing I'm concerned though is if this is enough: Couldn't the supplier still frontrun this given the fee amounts are still coming from the contracts into the frontend? Shouldn't we store the fees in the contract when the swap is created?

